### PR TITLE
Differentiate between powder and liquid casting and fix angels-gears.

### DIFF
--- a/angels-smelting-extended/changelog.txt
+++ b/angels-smelting-extended/changelog.txt
@@ -1,4 +1,14 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.0.4
+Date: 02.10.2020
+  Changes:
+    - Gears have been standardized across vanilla, Bob's, and Angel's components overhaul
+---------------------------------------------------------------------------------------------------
+Version: 1.0.3
+Date: 02.10.2020
+  Changes:
+    - Shielding casting recipes have been converted to strand casting
+---------------------------------------------------------------------------------------------------
 Version: 1.0.2
 Date: 02.10.2020
   Changes:

--- a/angels-smelting-extended/info.json
+++ b/angels-smelting-extended/info.json
@@ -1,6 +1,6 @@
 {
   "name": "angels-smelting-extended",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "factorio_version": "1.0",
   "title": "Angel's Extended Smelting and Compression",
   "author": "pezzawinkle",

--- a/angels-smelting-extended/migrations/smelting-extended_1.0.4.json
+++ b/angels-smelting-extended/migrations/smelting-extended_1.0.4.json
@@ -1,0 +1,12 @@
+{
+  "item":
+  [
+    ["angels-plate-brass", "brass-alloy"],
+    ["angels-plate-bronze", "bronze-alloy"],
+    ["angels-plate-gunmetal", "gunmetal-alloy"],
+    ["angels-plate-invar", "invar-alloy"],
+    ["angels-plate-electrum", "electrum-alloy"],
+    ["angels-plate-nitinol", "nitinol-alloy"],
+    ["angels-plate-cobalt-steel", "cobalt-steel-alloy"]
+  ]
+}

--- a/angels-smelting-extended/prototypes/data-tables.lua
+++ b/angels-smelting-extended/prototypes/data-tables.lua
@@ -32,8 +32,9 @@ gears = {
     "cobalt-steel",
     "tungsten"
 }
-a_inters = {
-    --["angels-gear"]={metal="iron"},--iron gear is now the angels-gear
+liquid_casting = {
+    ["angels-gear"] = { metal = "iron", icon = "gear", tech = "angels-components-mechanical-1", cost = 1, amount = 1 },
+    ["angels-mechanical-parts"] = { metal = "iron", icon = "mechanical-parts", tech = "angels-components-mechanical-1", cost = 1, amount = 1},
     ["angels-axle"] = { metal = "steel", icon = "axle", tech = "angels-components-mechanical-2", cost = 2, amount = 1 },
     ["angels-roller-chain"] = { metal = "aluminium", icon = "roller-chain", tech = "angels-components-mechanical-3", cost = 1, amount = 1 },
     ["angels-spring"] = { metal = "titanium", icon = "spring", tech = "angels-components-mechanical-4", cost = 1, amount = 1 },
@@ -42,27 +43,29 @@ a_inters = {
     ["grate-steel"] = { metal = "steel", tech = "angels-components-construction-2", cost = 2, amount = 0.5 },
     ["grate-aluminium"] = { metal = "aluminium", tech = "angels-components-construction-3", cost = 2, amount = 1 },
     ["grate-titanium"] = { metal = "titanium", tech = "angels-components-construction-4", cost = 2, amount = 1 },
-    ["grate-tungsten"] = { metal = "tungsten", tech = "angels-components-construction-5", cost = 2, amount = 1 },
     ["angels-girder"] = { metal = "iron", icon = "girder", tech = "angels-components-construction-2", cost = 1, amount = 1 },
     ["angels-rivet"] = { metal = "steel", icon = "rivet", tech = "angels-components-construction-2", cost = 1, amount = 1 },
     ["angels-bracket"] = { metal = "aluminium", icon = "bracket", tech = "angels-components-construction-3", cost = 1, amount = 1 },
     ["angels-plating"] = { metal = "titanium", icon = "plating", tech = "angels-components-construction-4", cost = 1, amount = 1 },
-    ["angels-strut"] = { metal = "tungsten", icon = "strut", tech = "angels-components-construction-5", cost = 1, amount = 1 },
     ["body-1"] = { metal = "iron", tech = "angels-components-weapons-basic", cost = 2, amount = 1 },
     ["body-2"] = { metal = "steel", tech = "military", cost = 2, amount = 1 },
     ["body-3"] = { metal = "aluminium", tech = "military-2", cost = 2, amount = 1 },
     ["body-4"] = { metal = "titanium", tech = "angels-components-weapons-advanced", cost = 2, amount = 1 },
-    ["body-5"] = { metal = "tungsten", tech = "military-3", cost = 2, amount = 1 },
     ["angels-trigger"] = { metal = "iron", icon = "trigger", tech = "angels-components-weapons-basic", cost = 1, amount = 1 },
     ["angels-explosionchamber"] = { metal = "steel", icon = "explosion-chamber", tech = "military", cost = 1, amount = 1 },
     ["angels-fluidchamber"] = { metal = "aluminium", icon = "fluid-chamber", tech = "military-2", cost = 1, amount = 1 },
     ["angels-energycrystal"] = { metal = "titanium", icon = "energy-chamber", tech = "angels-components-weapons-advanced", cost = 1, amount = 1 },
+}
+powder_casting = {
+    ["grate-tungsten"] = { metal = "tungsten", tech = "angels-components-construction-5", cost = 2, amount = 1 },
+    ["angels-strut"] = { metal = "tungsten", icon = "strut", tech = "angels-components-construction-5", cost = 1, amount = 1 },
+    ["body-5"] = { metal = "tungsten", tech = "military-3", cost = 2, amount = 1 },
     --["angels-acceleratorcoil"]={metal="tungsten",icon="accelerator-coil",tech="military-3"}
 }
 shielding = {
     { metal = "copper", order = "i-z" },
     { metal = "tin", order = "h-z" },
-    { metal = "silver", order = "l-z"},
-    { metal = "gold", order = "k-z"},
-    { metal = "platinum", order = "j-z"}
+    { metal = "silver", order = "l-z" },
+    { metal = "gold", order = "k-z" },
+    { metal = "platinum", order = "j-z" }
 }

--- a/angels-smelting-extended/prototypes/override.lua
+++ b/angels-smelting-extended/prototypes/override.lua
@@ -92,10 +92,15 @@ if mods["bobplates"] then
 end
 --find activation settings
 if mods["angelsindustries"] and angelsmods.industries.components then
-    for item, i in pairs(a_inters) do
-        angelsmods.functions.OV.add_unlock(i.tech, item .. "-casting")
-        angelsmods.functions.OV.add_unlock(i.tech, "ASE-" .. item .. "-casting-expendable")
-        angelsmods.functions.OV.add_unlock(i.tech, "ASE-" .. item .. "-casting-advanced")
+    for name, details in pairs(liquid_casting) do
+        angelsmods.functions.OV.add_unlock(details.tech, name .. "-casting")
+        angelsmods.functions.OV.add_unlock(details.tech, "ASE-" .. name .. "-casting-expendable")
+        angelsmods.functions.OV.add_unlock(details.tech, "ASE-" .. name .. "-casting-advanced")
+    end
+    for name, details in pairs(powder_casting) do
+        angelsmods.functions.OV.add_unlock(details.tech, name .. "-casting")
+        angelsmods.functions.OV.add_unlock(details.tech, "ASE-" .. name .. "-casting-expendable")
+        angelsmods.functions.OV.add_unlock(details.tech, "ASE-" .. name .. "-casting-advanced")
     end
     for n, item in pairs(shielding) do
         angelsmods.functions.OV.add_unlock("angels-" .. item.metal .. "-smelting-2", "angels-shielding-coil-" .. item.metal .. "-casting")

--- a/angels-smelting-extended/prototypes/recipes/ironworks.lua
+++ b/angels-smelting-extended/prototypes/recipes/ironworks.lua
@@ -2,347 +2,278 @@ require("prototypes.data-tables")
 -- IRONWORKS
 
 --SET-UP BASE CASTING RECIPES TO COPY LATER
-data:extend(
-{
-  {
-    type = "recipe",
-    name = "angels-iron-pipe-casting",
-    category = "casting",
-    subgroup = "angels-iron-casting",
-    energy_required = 4,
-    enabled = "false",
-    ingredients ={
-      {type="fluid", name="liquid-molten-iron", amount=40},
-    },
-    results=
+data:extend({
     {
-      {type="item", name="pipe", amount=4},
+        type = "recipe",
+        name = "angels-iron-pipe-casting",
+        category = "casting",
+        subgroup = "angels-iron-casting",
+        energy_required = 4,
+        enabled = "false",
+        ingredients = {
+            { type = "fluid", name = "liquid-molten-iron", amount = 40 },
+        },
+        results =
+        {
+            { type = "item", name = "pipe", amount = 4 },
+        },
+        order = "ya",
     },
-    order = "ya",
-  },
-  {
-    type = "recipe",
-    name = "angels-iron-pipe-to-ground-casting",
-    category = "casting",
-    subgroup = "angels-iron-casting",
-    energy_required = 2,
-    enabled = "false",
-    ingredients ={
-      {type="fluid", name="liquid-molten-iron", amount=150},
-    },
-    results=
     {
-      {type="item", name="pipe-to-ground", amount=2},
+        type = "recipe",
+        name = "angels-iron-pipe-to-ground-casting",
+        category = "casting",
+        subgroup = "angels-iron-casting",
+        energy_required = 2,
+        enabled = "false",
+        ingredients = {
+            { type = "fluid", name = "liquid-molten-iron", amount = 150 },
+        },
+        results =
+        {
+            { type = "item", name = "pipe-to-ground", amount = 2 },
+        },
+        order = "yb",
     },
-    order = "yb",
-  },
 })
 -- bobs pipe casting
 if mods["boblogistics"] and mods["bobplates"] then
-  --call pipe metal types (metal_tab)
-  for n,metal in pairs(metal_tab) do
-    --metal straight pipes
-    local m_pipe=table.deepcopy(data.raw.recipe["angels-iron-pipe-casting"])
-    m_pipe.name="angels-"..metal.."-pipe-casting"
-    m_pipe.subgroup="angels-"..metal.."-casting"
-    m_pipe.ingredients ={{type="fluid", name="liquid-molten-"..metal, amount=40},}
-    m_pipe.results={{type="item", name=metal.."-pipe", amount=4},}
-    --metal UG pipes
-    local u_pipe=table.deepcopy(data.raw.recipe["angels-iron-pipe-to-ground-casting"])
-    local ug_multi={
-      ["copper"]=150,
-      ["steel"]=170,
-      ["titanium"]=210,
-      ["brass"]=190,
-      ["bronze"]=170,
-      ["nitinol"]=230,
-      ["tungsten"]=21
-    }
-    --iron is 15x for UG
-    u_pipe.name="angels-"..metal.."-pipe-to-ground-casting"
-    u_pipe.subgroup="angels-"..metal.."-casting"
-    u_pipe.ingredients ={{type="fluid", name="liquid-molten-"..metal, amount=ug_multi[metal]},}
-    u_pipe.results={{type="item", name=metal.."-pipe-to-ground", amount=2},}
-    --tungsten-fixes
-    if metal=="tungsten" then
-      m_pipe.ingredients[1]={type="item", name="casting-powder-tungsten", amount=4}
-      m_pipe.category = "sintering"
-      u_pipe.ingredients[1]={type="item", name="casting-powder-tungsten", amount=ug_multi[metal]}
-      u_pipe.category = "sintering"
+    --call pipe metal types (metal_tab)
+    for n, metal in pairs(metal_tab) do
+        --metal straight pipes
+        local m_pipe = table.deepcopy(data.raw.recipe["angels-iron-pipe-casting"])
+        m_pipe.name = "angels-" .. metal .. "-pipe-casting"
+        m_pipe.subgroup = "angels-" .. metal .. "-casting"
+        m_pipe.ingredients = { { type = "fluid", name = "liquid-molten-" .. metal, amount = 40 }, }
+        m_pipe.results = { { type = "item", name = metal .. "-pipe", amount = 4 }, }
+        --metal UG pipes
+        local u_pipe = table.deepcopy(data.raw.recipe["angels-iron-pipe-to-ground-casting"])
+        local ug_multi = {
+            ["copper"] = 150,
+            ["steel"] = 170,
+            ["titanium"] = 210,
+            ["brass"] = 190,
+            ["bronze"] = 170,
+            ["nitinol"] = 230,
+            ["tungsten"] = 21
+        }
+        --iron is 15x for UG
+        u_pipe.name = "angels-" .. metal .. "-pipe-to-ground-casting"
+        u_pipe.subgroup = "angels-" .. metal .. "-casting"
+        u_pipe.ingredients = { { type = "fluid", name = "liquid-molten-" .. metal, amount = ug_multi[metal] }, }
+        u_pipe.results = { { type = "item", name = metal .. "-pipe-to-ground", amount = 2 }, }
+        --tungsten-fixes
+        if metal == "tungsten" then
+            m_pipe.ingredients[1] = { type = "item", name = "casting-powder-tungsten", amount = 4 }
+            m_pipe.category = "sintering"
+            u_pipe.ingredients[1] = { type = "item", name = "casting-powder-tungsten", amount = ug_multi[metal] }
+            u_pipe.category = "sintering"
+        end
+        data:extend({ m_pipe, u_pipe })
     end
-    data:extend({m_pipe,u_pipe})
-  end
 end
 --SETTING UP CASTING MOLD ITEMS and RECIPES
 data:extend({
-  --expendable mold recipe (want roasted)
-  {
-    type = "recipe",
-    name="ASE-sand-die",
-    category="sintering",
-    subgroup="angels-mold-casting",
-    energy_required= 8,
-    enabled="false",
-    icons={
-      {
-        icon = "__angelssmelting__/graphics/icons/expendable-mold.png",
+    --expendable mold recipe (want roasted)
+    {
+        type = "recipe",
+        name = "ASE-sand-die",
+        category = "sintering",
+        subgroup = "angels-mold-casting",
+        energy_required = 8,
+        enabled = "false",
+        icons = {
+            {
+                icon = "__angelssmelting__/graphics/icons/expendable-mold.png",
+                icon_size = 32,
+            },
+        },
         icon_size = 32,
-      },
+        ingredients = {
+            { type = "item", name = "solid-sand", amount = 40 },
+            { type = "item", name = "powder-steel", amount = 1 }
+        },
+        results = {
+            { type = "item", name = "ASE-sand-die", amount = 8 },
+        },
+        order = "aa",
     },
-    icon_size=32,
-    ingredients={
-      {type="item", name="solid-sand",amount=40},
-      {type="item",name="powder-steel", amount=1}
-    },
-    results={
-      {type="item",name="ASE-sand-die",amount=8},
-    },
-    order="aa",
-  },
-  --non-expendable mold recipe (initial)
-  {
-    type = "recipe",
-    name="ASE-metal-die",
-    category="sintering",
-    subgroup="angels-mold-casting",
-    icons={
-      {
-        icon = "__angelssmelting__/graphics/icons/non-expendable-mold.png",
+    --non-expendable mold recipe (initial)
+    {
+        type = "recipe",
+        name = "ASE-metal-die",
+        category = "sintering",
+        subgroup = "angels-mold-casting",
+        icons = {
+            {
+                icon = "__angelssmelting__/graphics/icons/non-expendable-mold.png",
+                icon_size = 32,
+            },
+            {
+                icon = "__angelsrefining__/graphics/icons/num_1.png",
+                tint = { r = 0.8, g = 0.8, b = 0.8, a = 0.5 },
+                scale = 0.32,
+                shift = { -12, -12 },
+            },
+        },
         icon_size = 32,
-      },
-      {
-        icon = "__angelsrefining__/graphics/icons/num_1.png",
-        tint = {r = 0.8, g = 0.8, b = 0.8, a = 0.5},
-        scale = 0.32,
-        shift = {-12, -12},
-      },
+        energy_required = 8,
+        enabled = "false",
+        ingredients = {
+            { type = "item", name = "solid-zinc-oxide", amount = 40 },
+            { type = "item", name = "powder-steel", amount = 10 }
+        },
+        results = {
+            { type = "item", name = "ASE-metal-die", amount = 8 },
+        },
+        order = "ab",
     },
-    icon_size=32,
-    energy_required= 8,
-    enabled="false",
-    ingredients={
-      {type="item", name="solid-zinc-oxide",amount=40},
-      {type="item",name="powder-steel", amount=10}
-    },
-    results={
-      {type="item",name="ASE-metal-die",amount=8},
-    },
-    order="ab",
-  },
 
-  --non-expendable mold washing
-  {
-    type = "recipe",
-    name="ASE-metal-die-wash",
-    category="crafting-with-fluid",
-    subgroup="angels-mold-casting",
-    energy_required= 8,
-    enabled="false",
-    icons={
-      {
-        icon = "__angelssmelting__/graphics/icons/non-expendable-mold.png",
+    --non-expendable mold washing
+    {
+        type = "recipe",
+        name = "ASE-metal-die-wash",
+        category = "crafting-with-fluid",
+        subgroup = "angels-mold-casting",
+        energy_required = 8,
+        enabled = "false",
+        icons = {
+            {
+                icon = "__angelssmelting__/graphics/icons/non-expendable-mold.png",
+                icon_size = 32,
+            },
+            { icon = "__angelsrefining__/graphics/icons/slag.png", icon_size = 32, scale = 0.6 },
+            {
+                icon = "__angelsrefining__/graphics/icons/num_2.png",
+                icon_size = 32,
+                tint = { r = 0.8, g = 0.8, b = 0.8, a = 0.5 },
+                scale = 0.32,
+                shift = { -12, -12 },
+            },
+        },
         icon_size = 32,
-      },
-      {icon = "__angelsrefining__/graphics/icons/slag.png",icon_size=32,scale=0.6},
-      {
-        icon = "__angelsrefining__/graphics/icons/num_2.png",
-        icon_size=32,
-        tint = {r = 0.8, g = 0.8, b = 0.8, a = 0.5},
-        scale = 0.32,
-        shift = {-12, -12},
-      },
+        ingredients = {
+            { type = "item", name = "ASE-spent-metal-die", amount = 3 },
+            { type = "fluid", name = "liquid-nitric-acid", amount = 20 }
+        },
+        results = {
+            { type = "item", name = "ASE-metal-die", amount = 3 },
+            { type = "fluid", name = "water-red-waste", amount = 20 },
+        },
+        order = "ac",
     },
-    icon_size=32,
-    ingredients={
-      {type="item", name="ASE-spent-metal-die",amount=3},
-      {type="fluid",name="liquid-nitric-acid", amount=20}
-    },
-    results={
-      {type="item",name="ASE-metal-die",amount=3},
-      {type="fluid",name="water-red-waste", amount=20},
-    },
-    order="ac",
-  },
 })
---SET-UP BASE CASTING RECIPES TO COPY LATER
---iron gears
-data:extend(
-{
-  {
-    type = "recipe",
-    name = "angels-iron-gear-wheel-casting",
-    category = "casting",
-    subgroup = "angels-iron-casting",
-    localised_name={"recipe-name.reg-casting",{"lookup.iron"},"Gear Wheel"},
-    energy_required = 2,
-    enabled = "false",
-    ingredients ={
-      {type="fluid", name="liquid-molten-iron", amount=80},
-    },
-    results=
-    {
-      {type="item", name="iron-gear-wheel", amount=8},
-    },
-    order = "yc",
-  },
-  {
-    type = "recipe",
-    name = "ASE-iron-gear-casting-expendable",
-    category = "casting",
-    subgroup = "angels-iron-casting",
-    localised_name={"recipe-name.sand-casting",{"lookup.iron"},"Gear Wheel"},
-    energy_required = 0.5,
-    enabled = "false",
-    icons={
-      {
-        icon="__base__/graphics/icons/iron-gear-wheel.png",icon_size=64,
-      },
-      {
-        icon = "__angelssmelting__/graphics/icons/expendable-mold.png",
-        icon_size = 32,
-        scale = 0.32,
-        shift = {-12, -12},
-      },
-    },
-    ingredients ={
-      {type="fluid", name="liquid-molten-iron", amount=80},
-      {type="item", name="ASE-sand-die",amount=2}
-    },
-    results=
-    {
-      {type="item", name="iron-gear-wheel", amount=11},
-      {type="item", name="solid-sand", amount=5},
-    },
-    order = "yd",
-  },
-  {
-    type = "recipe",
-    name = "ASE-iron-gear-casting-advanced",
-    category = "casting",
-    subgroup = "angels-iron-casting",
-    localised_name={"recipe-name.die-casting",{"lookup.iron"},"Gear Wheel"},
-    energy_required = 0.5,
-    enabled = "false",
-    icons={
-      {
-        icon="__base__/graphics/icons/iron-gear-wheel.png",icon_size=64,
-      },
-      {
-        icon = "__angelssmelting__/graphics/icons/non-expendable-mold.png",
-        icon_size = 32,
-        scale = 0.32,
-        shift = {-12, -12},
-      },
-    },
-    ingredients ={
-      {type="fluid", name="liquid-molten-iron", amount=80},
-      {type="item", name="ASE-metal-die",amount=3},
-    },
-    results=
-    {
-      {type="item", name="iron-gear-wheel", amount=15},
-      {type="item", name="ASE-spent-metal-die",amount=3},
-    },
-    order = "ye",
-  },
-})
-if mods["bobplates"] then
-for n,metal in pairs(gears) do
-    -- regular casting
-    local m_gear1=table.deepcopy(data.raw.recipe["angels-iron-gear-wheel-casting"])
-    m_gear1.name = "angels-"..metal.."-gear-wheel-casting"
-    m_gear1.subgroup = "angels-"..metal.."-casting"
-    m_gear1.localised_name={"recipe-name.reg-casting",{"lookup."..metal},"Gear Wheel"}
-    m_gear1.ingredients ={{type="fluid", name="liquid-molten-"..metal, amount=40},}
-    m_gear1.results={{type="item", name=metal.."-gear-wheel", amount=9},}
-    -- expendable casting
-    local m_gear2=table.deepcopy(data.raw.recipe["ASE-iron-gear-casting-expendable"])
-    m_gear2.name = "ASE-"..metal.."-gear-casting-expendable"
-    m_gear2.subgroup = "angels-"..metal.."-casting"
-    m_gear2.localised_name={"recipe-name.sand-casting",{"lookup."..metal},"Gear Wheel"}
-    m_gear2.icons[1]={icon="__bobplates__/graphics/icons/"..metal.."-gear-wheel.png",icon_size=32,}
-    m_gear2.ingredients ={
-      {type="fluid", name="liquid-molten-"..metal, amount=80},
-      {type="item", name="ASE-sand-die",amount=2}
-    }
-    m_gear2.results=
-    {
-      {type="item", name= metal.."-gear-wheel", amount=11},
-      {type="item", name="solid-sand", amount=5},
-    }
-    -- non-expendable casting
-    local m_gear3=table.deepcopy(data.raw.recipe["ASE-iron-gear-casting-advanced"])
-    m_gear3.name = "ASE-"..metal.."-gear-casting-advanced"
-    m_gear3.subgroup = "angels-"..metal.."-casting"
-    m_gear3.localised_name={"recipe-name.die-casting",{"lookup."..metal},"Gear Wheel"}
-    m_gear3.icons[1]={icon="__bobplates__/graphics/icons/"..metal.."-gear-wheel.png",icon_size=32,}
-    m_gear3.ingredients ={
-      {type="fluid", name="liquid-molten-"..metal, amount=80},
-      {type="item", name="ASE-metal-die",amount=3},
-    }
-    m_gear3.results=
-    {
-      {type="item", name=metal.."-gear-wheel", amount=15},
-      {type="item", name="ASE-spent-metal-die",amount=3},
-    }
-    --tungsten-fixes
-    if metal=="tungsten" then
-      m_gear1.ingredients[1]={type="item", name="casting-powder-tungsten", amount=12}
-      m_gear1.category = "sintering"
-      m_gear2.ingredients[1]={type="item", name="casting-powder-tungsten", amount=12}
-      m_gear2.category = "sintering"
-      m_gear3.ingredients[1]={type="item", name="casting-powder-tungsten", amount=12}
-      m_gear3.category = "sintering"
-    end
-    data:extend({m_gear1,m_gear2,m_gear3})
-  end
+
+local function add_casting_recipes(name, category, metal, ingredient, cost, amount, icon)
+    data:extend({
+        {
+            type = "recipe",
+            name = "angels-" .. name .. "-casting",
+            category = category,
+            subcategory = "angels-" .. metal .. "-casting",
+            energy_required = 4,
+            enabled = "false",
+            ingredients = {
+                { ingredient.type, ingredient.name, amount = 40 * cost }
+            },
+            results = {
+                { type = "item", name = name, amount = 4 * amount }
+            }
+        },
+        {
+            type = "recipe",
+            name = "ASE-" .. name .. "-casting-expendable",
+            category = category,
+            subcategory = "angels-" .. metal .. "-casting",
+            energy_required = 4,
+            enabled = "false",
+            icons = {
+                {
+                    icon = "__" .. icon.mod .. "__/graphics/icons/" .. icon.name .. ".png",
+                    icon_size = icon.size,
+                },
+                {
+                    icon = "__angelssmelting__/graphics/icons/expendable-mold.png",
+                    icon_size = 32,
+                    scale = 0.32,
+                    shift = { -12, -12 },
+                },
+            },
+            ingredients = {
+                { ingredient.type, ingredient.name, amount = 60 * cost },
+                { type = "item", name = "ASE-sand-die", amount = 2 }
+            },
+            results = {
+                { type = "item", name = name, amount = 8 * amount },
+                { type = "item", name = "solid-sand", amount = 5 },
+            }
+        },
+        {
+            type = "recipe",
+            name = "ASE-" .. name .. "-casting-advanced",
+            category = category,
+            subcategory = "angels-" .. metal .. "-casting",
+            energy_required = 2,
+            enabled = "false",
+            icons = {
+                {
+                    icon = "__" .. icon.mod .. "__/graphics/icons/" .. icon.name .. ".png",
+                    icon_size = icon.size,
+                },
+                {
+                    icon = "__angelssmelting__/graphics/icons/non-expendable-mold.png",
+                    icon_size = 32,
+                    scale = 0.32,
+                    shift = { -12, -12 },
+                },
+            },
+            ingredients = {
+                { ingredient.type, ingredient.name, amount = 110 * cost },
+                { type = "item", name = "ASE-metal-die", amount = 3 },
+            },
+            results = {
+                { type = "item", name = name, amount = 16 * amount },
+                { type = "item", name = "ASE-spent-metal-die", amount = 3 },
+            }
+        }
+    })
 end
-if mods["angelsindustries"] and (settings.startup["angels-enable-components"].value or settings.startup["angels-enable-tech"].value) then
 
-  for item,i in pairs(a_inters) do
-    local ico_name={}
-    if i.icon then
-      ico_name=i.icon
-    else
-      ico_name=item
-    end
-    item_n = item:gsub("(%l)(%w*)", function(a,b) return string.upper(a)..b end)
-    -- regular casting
-    local m_inter1=table.deepcopy(data.raw.recipe["angels-iron-gear-wheel-casting"])
-    m_inter1.name=item.."-casting"
-    m_inter1.subgroup = "angels-"..i.metal.."-casting"
-    m_inter1.localised_name = {"recipe-name.angels-advanced-regular", item_n}
-    m_inter1.ingredients={{type="fluid", name="liquid-molten-"..i.metal, amount=40*i.cost},}
-    m_inter1.results={{type="item", name=item, amount=4*i.amount},}
-    m_inter1.order="z["..item.."]-c"
-    -- expendable casting
-    local m_inter2=table.deepcopy(data.raw.recipe["ASE-iron-gear-casting-expendable"])
-    m_inter2.name="ASE-"..item.."-casting-expendable"
-    m_inter2.subgroup = "angels-"..i.metal.."-casting"
-    m_inter2.localised_name = {"recipe-name.angels-advanced-expendable", item_n}
-    m_inter2.icons[1]={icon="__angelsindustries__/graphics/icons/"..ico_name..".png",icon_size=32,}
-    m_inter2.ingredients[1]={type="fluid", name="liquid-molten-"..i.metal, amount=60*i.cost}
-    m_inter2.results[1]={type="item", name=item, amount=8*i.amount}
-    m_inter2.order="z["..item.."]-d"
-    --non-expendable casting
-    local m_inter3=table.deepcopy(data.raw.recipe["ASE-iron-gear-casting-advanced"])
-    m_inter3.name="ASE-"..item.."-casting-advanced"
-    m_inter3.subgroup = "angels-"..i.metal.."-casting"
-    m_inter3.localised_name = {"recipe-name.angels-advanced-crafting", item_n}
-    m_inter3.icons[1]={icon="__angelsindustries__/graphics/icons/"..ico_name..".png",icon_size=32,}
-    m_inter3.ingredients[1]={type="fluid", name="liquid-molten-"..i.metal, amount=80*i.cost}
-    m_inter3.results[1]={type="item", name=item, amount=12*i.amount}
-    m_inter3.order="z["..item.."]-e"
+local function add_liquid_casting_recipes(name, metal, cost, amount, icon)
+    local ingredient = { type = "fluid", name = "liquid-molten-" .. metal }
+    add_casting_recipes(name, "casting", metal, ingredient, cost, amount, icon)
+end
 
-    --tungsten-fixes
-    if i.metal=="tungsten" then
-      m_inter1.ingredients[1]={type="item", name="casting-powder-tungsten", amount=4*i.cost}
-      m_inter1.category = "sintering"
-      m_inter2.ingredients[1]={type="item", name="casting-powder-tungsten", amount=6*i.cost}
-      m_inter2.category = "sintering"
-      m_inter3.ingredients[1]={type="item", name="casting-powder-tungsten", amount=8*i.cost}
-      m_inter3.category = "sintering"
+local function add_powder_casting_recipes(name, metal, cost, amount, icon)
+    local ingredient = { type = "item", name = "casting-powder-" .. metal }
+    add_casting_recipes(name, "sintering", metal, ingredient, cost, amount, icon)
+end
+
+if mods["angelsindustries"] and angelsmods.industries.components then
+    local function icon(name)
+        return { mod = "angelsindustries", name = name, size = 32 }
     end
-    data:extend({m_inter1,m_inter2,m_inter3})
-  end
+
+    for name, details in pairs(liquid_casting) do
+        add_liquid_casting_recipes(name, details.metal, details.cost, details.amount, icon(name))
+    end
+
+    for name, details in pairs(powder_casting) do
+        add_powder_casting_recipes(name, details.metal, details.cost, details.amount, icon(name))
+    end
+else
+    add_liquid_casting_recipes("iron-gear-wheel", "iron", 1, 1, { mod = "base", name = "iron-gear-wheel", size = 64 })
+
+    if mods["bobplates"] then
+        local function icon(name)
+            return { mod = "bobplates", name = name, size = 32 }
+        end
+
+        add_liquid_casting_recipes("steel-gear-wheel", "steel", 1, 1, icon("steel-gear-wheel"))
+        add_liquid_casting_recipes("nitinol-gear-wheel", "nitinol", 1, 1, icon("nitinol-gear-wheel"))
+        add_liquid_casting_recipes("titanium-gear-wheel", "titanium", 1, 1, icon("titanium-gear-wheel"))
+        add_liquid_casting_recipes("brass-gear-wheel", "brass", 1, 1, icon("brass-gear-wheel"))
+        add_liquid_casting_recipes("cobalt-steel-gear-wheel", "cobalt-steel", 1, 1, icon("cobalt-steel-gear-wheel"))
+        add_powder_casting_recipes("tungsten-gear-wheel", "tungsten", 0.1, 1, icon("tungsten-gear-wheel"))
+    end
 end


### PR DESCRIPTION
Fix gears and mechanical parts, differentiate between liquid and powder casting, and restructure ironworks.lua so that iron gears aren't the basis of all crafting recipes (since they are no longer added at all if components mode is enabled).